### PR TITLE
added a bit of syntax sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,19 @@ export const fillForm: Story = async (p) => {
     .in(customSelect)
     ...;
 };
+
+// threrd story: submit form
+export const submitForm: Story = async (p) => {
+  await p
+    .click(selector);
+};
+
+// fourth story: assert
+export const elementIsVisible: Story = async (p) => {
+  await p
+    .expectThatSelector(selector)
+    .isVisible();
+};
 ```
 
 `test.ts`
@@ -217,6 +230,15 @@ const p = new PlaywrightFluent();
 await p
   .runStory(startApp, { browser: 'chrome', isHeadless: false, url: 'http://example.com' })
   .runStory(fillForm)
+  .close();
+
+// Also methods synonyms are available to achieve better readability
+const user = new PlaywrightFluent();
+await user
+  .do(startApp, { browser: 'chrome', isHeadless: false, url: 'http://example.com' })
+  .and(fillForm)
+  .attemptsTo(submitForm)
+  .verifyIf(elementIsVisible)
   .close();
 ```
 

--- a/src/fluent-api/playwright-fluent.ts
+++ b/src/fluent-api/playwright-fluent.ts
@@ -1824,18 +1824,37 @@ export class PlaywrightFluent implements PromiseLike<void> {
     return result;
   }
 
-  public runStory<T>(story: Story | StoryWithProps<T>, param?: T): PlaywrightFluent {
+  private registerStory<T>(story: Story | StoryWithProps<T>, param?: T): PlaywrightFluent {
     if (typeof story !== 'function') {
       throw new Error('Story should be a function');
     }
 
     if (param === undefined) {
       this.actions.push(async (): Promise<void> => await (story as Story)(this));
-      return this;
+    } else {
+      this.actions.push(async (): Promise<void> => await story(this, param));
     }
-
-    this.actions.push(async (): Promise<void> => await story(this, param));
     return this;
+  }
+
+  public runStory<T>(story: Story | StoryWithProps<T>, param?: T): PlaywrightFluent {
+    return this.registerStory(story, param);
+  }
+
+  public attemptsTo<T>(story: Story | StoryWithProps<T>, param?: T): PlaywrightFluent {
+    return this.registerStory(story, param);
+  }
+
+  public and<T>(story: Story | StoryWithProps<T>, param?: T): PlaywrightFluent {
+    return this.registerStory(story, param);
+  }
+
+  public do<T>(story: Story | StoryWithProps<T>, param?: T): PlaywrightFluent {
+    return this.registerStory(story, param);
+  }
+
+  public verifyIf<T>(story: Story | StoryWithProps<T>, param?: T): PlaywrightFluent {
+    return this.registerStory(story, param);
   }
 
   /**

--- a/src/fluent-api/playwright-fluent.ts
+++ b/src/fluent-api/playwright-fluent.ts
@@ -1833,6 +1833,7 @@ export class PlaywrightFluent implements PromiseLike<void> {
       this.actions.push(async (): Promise<void> => await (story as Story)(this));
       return this;
     }
+
     this.actions.push(async (): Promise<void> => await story(this, param));
     return this;
   }

--- a/src/fluent-api/playwright-fluent.ts
+++ b/src/fluent-api/playwright-fluent.ts
@@ -1831,9 +1831,9 @@ export class PlaywrightFluent implements PromiseLike<void> {
 
     if (param === undefined) {
       this.actions.push(async (): Promise<void> => await (story as Story)(this));
-    } else {
-      this.actions.push(async (): Promise<void> => await story(this, param));
+      return this;
     }
+    this.actions.push(async (): Promise<void> => await story(this, param));
     return this;
   }
 

--- a/src/fluent-api/tests/run-story/run-story.chromium.test.ts
+++ b/src/fluent-api/tests/run-story/run-story.chromium.test.ts
@@ -97,7 +97,7 @@ describe('Playwright Fluent - runStory', (): void => {
       // prettier-ignore
       await p
         .runStory(storyA1)
-        .runStory(storyA2);
+        .and(storyA2);
     };
 
     const storyB1: SUT.Story = async (p) => {
@@ -114,18 +114,18 @@ describe('Playwright Fluent - runStory', (): void => {
       results.push('storyB');
       // prettier-ignore
       await p
-        .runStory(storyB1)
-        .runStory(storyB2);
+        .do(storyB1)
+        .and(storyB2);
     };
 
     const mainStory: SUT.Story = async (p) => {
       // prettier-ignore
-      await p.runStory(storyA);
-      await p.runStory(storyB);
+      await p.attemptsTo(storyA);
+      await p.and(storyB);
     };
 
     // When
-    await p.runStory(mainStory);
+    await p.verifyIf(mainStory);
 
     // Then
     expect(results.join()).toBe('storyA,storyA1,storyA2,storyB,storyB1,storyB2');


### PR DESCRIPTION
In my project I have plenty of  places looks next:

`await p.runStory(....);`
`await p.runStory(....);`
`await p.runStory(....);`
`await p.runStory(....);`
`await p.runStory(....);`
 
 
 So I see useful to be able wright sequences of stories a bit more readable:  
 

 `await user.do(...)`
 `await user.and(...);`
 `await user.attemptsTo(...);`
 `await user.verifyIf(...);`
